### PR TITLE
perf: bound log scanner and parallelize workspace scan

### DIFF
--- a/src/core/scanner/logs.ts
+++ b/src/core/scanner/logs.ts
@@ -1,9 +1,19 @@
 // Port of internal/scanner/logs.go — file-based Copilot log scanning.
 
 import * as fs from 'fs';
+import * as fsp from 'fs/promises';
 import * as path from 'path';
 import * as os from 'os';
 import { catalog } from '../featureCatalog';
+
+/** Skip log files older than this (7 days). */
+export const LOG_MTIME_CUTOFF_MS = 7 * 86_400_000;
+/** Per-file size cap (2 MB) — larger files are tail-read. */
+export const MAX_LOG_BYTES = 2 * 1024 * 1024;
+/** Hard cap on total parsed entries per scan. */
+export const MAX_ENTRIES = 50_000;
+/** Limit how many workspaceStorage debug-log folders we walk (most-recent first). */
+export const MAX_WORKSPACE_STORAGE_DIRS = 10;
 
 /** LogEntry represents a single Copilot log entry. */
 export interface LogEntry {
@@ -87,8 +97,10 @@ function getCopilotLogPath(): string | undefined {
   }
 }
 
-/** Get paths to all GitHub Copilot Chat debug-logs folders in workspaceStorage. */
-export function getWorkspaceStorageDebugLogPaths(): string[] {
+/** Get paths to GitHub Copilot Chat debug-logs folders in workspaceStorage,
+ *  capped to the {@link MAX_WORKSPACE_STORAGE_DIRS} most recently modified
+ *  workspace folders. */
+export async function getWorkspaceStorageDebugLogPaths(): Promise<string[]> {
   const homeDir = os.homedir();
   let storageBase: string;
   switch (process.platform) {
@@ -108,21 +120,38 @@ export function getWorkspaceStorageDebugLogPaths(): string[] {
       return [];
   }
 
-  const debugLogPaths: string[] = [];
   try {
-    const workspaceFolders = fs.readdirSync(storageBase, { withFileTypes: true })
-      .filter(d => d.isDirectory())
-      .map(d => path.join(storageBase, d.name));
-    for (const wsFolder of workspaceFolders) {
-      const debugLogsPath = path.join(wsFolder, 'GitHub.copilot-chat', 'debug-logs');
-      if (fs.existsSync(debugLogsPath)) {
+    const dirents = await fsp.readdir(storageBase, { withFileTypes: true });
+    const candidates: { dir: string; mtimeMs: number }[] = [];
+    await Promise.all(
+      dirents
+        .filter(d => d.isDirectory())
+        .map(async d => {
+          const dir = path.join(storageBase, d.name);
+          try {
+            const st = await fsp.stat(dir);
+            candidates.push({ dir, mtimeMs: st.mtimeMs });
+          } catch {
+            // Skip
+          }
+        }),
+    );
+    candidates.sort((a, b) => b.mtimeMs - a.mtimeMs);
+
+    const debugLogPaths: string[] = [];
+    for (const { dir } of candidates.slice(0, MAX_WORKSPACE_STORAGE_DIRS)) {
+      const debugLogsPath = path.join(dir, 'GitHub.copilot-chat', 'debug-logs');
+      try {
+        await fsp.access(debugLogsPath);
         debugLogPaths.push(debugLogsPath);
+      } catch {
+        // Skip missing
       }
     }
+    return debugLogPaths;
   } catch {
-    // Skip on access errors
+    return [];
   }
-  return debugLogPaths;
 }
 
 /** Check if a file path is a Copilot log. */
@@ -134,87 +163,134 @@ function isCopilotLog(filePath: string): boolean {
   );
 }
 
-/** Parse a single log file into entries. */
-function parseLogFile(filePath: string): LogEntry[] {
-  const entries: LogEntry[] = [];
+/** Read at most {@link MAX_LOG_BYTES} from `filePath`. For oversized files we
+ *  open and read the trailing window so the most recent entries survive,
+ *  discarding the first (likely partial) line. */
+async function readBoundedFile(filePath: string, size: number): Promise<string> {
+  if (size <= MAX_LOG_BYTES) {
+    return fsp.readFile(filePath, 'utf-8');
+  }
+  const fh = await fsp.open(filePath, 'r');
   try {
-    const content = fs.readFileSync(filePath, 'utf-8');
-    for (const line of content.split('\n')) {
-      const trimmed = line.trim();
-      if (!trimmed) {
-        continue;
-      }
-      try {
-        const parsed = JSON.parse(trimmed);
-        // Detect workspaceStorage debug-log format (has numeric ts and string type)
-        if (typeof parsed.ts === 'number' && typeof parsed.type === 'string') {
-          const attrs = (parsed.attrs ?? {}) as Record<string, unknown>;
-          const entry: LogEntry = {
-            timestamp: new Date(parsed.ts).toISOString(),
-            level: parsed.status === 'error' ? 'error' : 'info',
-            message: (parsed.name ?? parsed.type) as string,
-            source: filePath,
-            data: { type: parsed.type, name: parsed.name, dur: parsed.dur, ...attrs },
-          };
-          entries.push(entry);
-        } else {
-          const entry: LogEntry = {
-            timestamp: parsed.timestamp ?? new Date().toISOString(),
-            level: parsed.level ?? 'info',
-            message: parsed.message ?? parsed.msg ?? trimmed,
-            source: filePath,
-            data: parsed.data ?? parsed,
-          };
-          entries.push(entry);
-        }
-      } catch {
+    const buf = Buffer.alloc(MAX_LOG_BYTES);
+    await fh.read(buf, 0, MAX_LOG_BYTES, size - MAX_LOG_BYTES);
+    const text = buf.toString('utf-8');
+    const nl = text.indexOf('\n');
+    return nl >= 0 ? text.slice(nl + 1) : text;
+  } finally {
+    await fh.close();
+  }
+}
+
+/** Parse a single log file into entries. Returns an empty array on errors. */
+async function parseLogFile(filePath: string, size: number): Promise<LogEntry[]> {
+  const entries: LogEntry[] = [];
+  let content: string;
+  try {
+    content = await readBoundedFile(filePath, size);
+  } catch {
+    return entries;
+  }
+  for (const line of content.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      continue;
+    }
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (typeof parsed.ts === 'number' && typeof parsed.type === 'string') {
+        const attrs = (parsed.attrs ?? {}) as Record<string, unknown>;
         entries.push({
-          timestamp: new Date().toISOString(),
-          level: 'info',
-          message: trimmed,
+          timestamp: new Date(parsed.ts).toISOString(),
+          level: parsed.status === 'error' ? 'error' : 'info',
+          message: (parsed.name ?? parsed.type) as string,
           source: filePath,
+          data: { type: parsed.type, name: parsed.name, dur: parsed.dur, ...attrs },
+        });
+      } else {
+        entries.push({
+          timestamp: parsed.timestamp ?? new Date().toISOString(),
+          level: parsed.level ?? 'info',
+          message: parsed.message ?? parsed.msg ?? trimmed,
+          source: filePath,
+          data: parsed.data ?? parsed,
         });
       }
+    } catch {
+      entries.push({
+        timestamp: new Date().toISOString(),
+        level: 'info',
+        message: trimmed,
+        source: filePath,
+      });
     }
-  } catch {
-    // Skip unreadable files
   }
   return entries;
 }
 
-/** Recursively read log files from a directory. */
-function readLogFiles(logPath: string): LogEntry[] {
-  const entries: LogEntry[] = [];
-  try {
-    const walk = (dir: string) => {
-      const items = fs.readdirSync(dir, { withFileTypes: true });
-      for (const item of items) {
-        const full = path.join(dir, item.name);
-        if (item.isDirectory()) {
-          walk(full);
-        } else if (isCopilotLog(full)) {
-          entries.push(...parseLogFile(full));
-        }
+/** Recursively read log files from a directory, applying mtime/size/count caps.
+ *  Walks the tree and pushes entries into `entries`; returns true when the
+ *  global {@link MAX_ENTRIES} cap has been hit and walking should stop.
+ *  Exported for testing. */
+export async function readLogFiles(logPath: string, entries: LogEntry[]): Promise<boolean> {
+  const cutoff = Date.now() - LOG_MTIME_CUTOFF_MS;
+
+  const walk = async (dir: string): Promise<boolean> => {
+    let items: fs.Dirent[];
+    try {
+      items = await fsp.readdir(dir, { withFileTypes: true });
+    } catch {
+      return false;
+    }
+    for (const item of items) {
+      if (entries.length >= MAX_ENTRIES) { return true; }
+      const full = path.join(dir, item.name);
+      if (item.isDirectory()) {
+        const stop = await walk(full);
+        if (stop) { return true; }
+        continue;
       }
-    };
-    walk(logPath);
-  } catch {
-    // Directory may not exist
-  }
-  return entries;
+      if (!isCopilotLog(full)) { continue; }
+      let st: fs.Stats;
+      try {
+        st = await fsp.stat(full);
+      } catch {
+        continue;
+      }
+      if (st.mtimeMs < cutoff) { continue; }
+      const parsed = await parseLogFile(full, st.size);
+      for (const e of parsed) {
+        if (entries.length >= MAX_ENTRIES) { return true; }
+        entries.push(e);
+      }
+    }
+    return false;
+  };
+
+  return walk(logPath);
 }
 
-/** ScanCopilotLogs scans VS Code Copilot logs and returns parsed entries. */
-export function scanCopilotLogs(): LogEntry[] {
+/** ScanCopilotLogs scans VS Code Copilot logs and returns parsed entries.
+ *  Bounded by mtime, per-file size, and total entry caps so activation does
+ *  not block on tens of MB of historical logs. */
+export async function scanCopilotLogs(): Promise<LogEntry[]> {
   const entries: LogEntry[] = [];
 
   const logPath = getCopilotLogPath();
-  if (logPath && fs.existsSync(logPath)) {
-    entries.push(...readLogFiles(logPath));
+  if (logPath) {
+    try {
+      await fsp.access(logPath);
+      const stop = await readLogFiles(logPath, entries);
+      if (stop) { return entries; }
+    } catch {
+      // Path missing — skip
+    }
   }
 
-  for (const debugLogPath of getWorkspaceStorageDebugLogPaths()) {
-    entries.push(...readLogFiles(debugLogPath));
+  for (const debugLogPath of await getWorkspaceStorageDebugLogPaths()) {
+    if (entries.length >= MAX_ENTRIES) { break; }
+    const stop = await readLogFiles(debugLogPath, entries);
+    if (stop) { break; }
   }
 
   return entries;

--- a/src/core/scanner/logs.ts
+++ b/src/core/scanner/logs.ts
@@ -4,6 +4,7 @@ import * as fs from 'fs';
 import * as fsp from 'fs/promises';
 import * as path from 'path';
 import * as os from 'os';
+import { StringDecoder } from 'string_decoder';
 import { catalog } from '../featureCatalog';
 
 /** Skip log files older than this (7 days). */
@@ -174,7 +175,7 @@ async function readBoundedFile(filePath: string, size: number): Promise<string> 
   try {
     const buf = Buffer.alloc(MAX_LOG_BYTES);
     const { bytesRead } = await fh.read(buf, 0, MAX_LOG_BYTES, size - MAX_LOG_BYTES);
-    const text = buf.subarray(0, bytesRead).toString('utf-8');
+    const text = new StringDecoder('utf8').write(buf.subarray(0, bytesRead));
     const nl = text.indexOf('\n');
     return nl >= 0 ? text.slice(nl + 1) : text;
   } finally {

--- a/src/core/scanner/logs.ts
+++ b/src/core/scanner/logs.ts
@@ -173,8 +173,8 @@ async function readBoundedFile(filePath: string, size: number): Promise<string> 
   const fh = await fsp.open(filePath, 'r');
   try {
     const buf = Buffer.alloc(MAX_LOG_BYTES);
-    await fh.read(buf, 0, MAX_LOG_BYTES, size - MAX_LOG_BYTES);
-    const text = buf.toString('utf-8');
+    const { bytesRead } = await fh.read(buf, 0, MAX_LOG_BYTES, size - MAX_LOG_BYTES);
+    const text = buf.subarray(0, bytesRead).toString('utf-8');
     const nl = text.indexOf('\n');
     return nl >= 0 ? text.slice(nl + 1) : text;
   } finally {
@@ -183,7 +183,7 @@ async function readBoundedFile(filePath: string, size: number): Promise<string> 
 }
 
 /** Parse a single log file into entries. Returns an empty array on errors. */
-async function parseLogFile(filePath: string, size: number): Promise<LogEntry[]> {
+async function parseLogFile(filePath: string, size: number, maxEntries: number = Number.POSITIVE_INFINITY): Promise<LogEntry[]> {
   const entries: LogEntry[] = [];
   let content: string;
   try {
@@ -192,6 +192,9 @@ async function parseLogFile(filePath: string, size: number): Promise<LogEntry[]>
     return entries;
   }
   for (const line of content.split('\n')) {
+    if (entries.length >= maxEntries) {
+      break;
+    }
     const trimmed = line.trim();
     if (!trimmed) {
       continue;
@@ -258,11 +261,13 @@ export async function readLogFiles(logPath: string, entries: LogEntry[]): Promis
         continue;
       }
       if (st.mtimeMs < cutoff) { continue; }
-      const parsed = await parseLogFile(full, st.size);
+      const remainingEntries = MAX_ENTRIES - entries.length;
+      const parsed = await parseLogFile(full, st.size, remainingEntries);
       for (const e of parsed) {
         if (entries.length >= MAX_ENTRIES) { return true; }
         entries.push(e);
       }
+      if (entries.length >= MAX_ENTRIES) { return true; }
     }
     return false;
   };

--- a/src/core/scanner/logs.ts
+++ b/src/core/scanner/logs.ts
@@ -175,7 +175,7 @@ async function readBoundedFile(filePath: string, size: number): Promise<string> 
   try {
     const buf = Buffer.alloc(MAX_LOG_BYTES);
     const { bytesRead } = await fh.read(buf, 0, MAX_LOG_BYTES, size - MAX_LOG_BYTES);
-    const text = new StringDecoder('utf8').write(buf.subarray(0, bytesRead));
+    const text = new StringDecoder('utf8').end(buf.subarray(0, bytesRead));
     const nl = text.indexOf('\n');
     return nl >= 0 ? text.slice(nl + 1) : text;
   } finally {
@@ -265,10 +265,9 @@ export async function readLogFiles(logPath: string, entries: LogEntry[]): Promis
       const remainingEntries = MAX_ENTRIES - entries.length;
       const parsed = await parseLogFile(full, st.size, remainingEntries);
       for (const e of parsed) {
-        if (entries.length >= MAX_ENTRIES) { return true; }
         entries.push(e);
+        if (entries.length >= MAX_ENTRIES) { return true; }
       }
-      if (entries.length >= MAX_ENTRIES) { return true; }
     }
     return false;
   };

--- a/src/core/scanner/workspace.ts
+++ b/src/core/scanner/workspace.ts
@@ -45,11 +45,17 @@ export async function scanWorkspace(): Promise<WorkspaceResult> {
     }
   }
 
-  // Scan the workspace for each file-path hint pattern
-  for (const hint of fileHints) {
-    const pattern = new vscode.RelativePattern(folders[0], hint);
-    const isGlob = hint.includes('*');
-    const files = await vscode.workspace.findFiles(pattern, '**/node_modules/**', isGlob ? 10 : 1);
+  // Scan in parallel — findFiles is independent per pattern.
+  const results = await Promise.all(
+    fileHints.map(async (hint) => {
+      const isGlob = hint.includes('*');
+      const pattern = new vscode.RelativePattern(folders[0], hint);
+      const files = await vscode.workspace.findFiles(pattern, '**/node_modules/**', isGlob ? 10 : 1);
+      return [hint, files] as const;
+    }),
+  );
+
+  for (const [hint, files] of results) {
     for (const file of files) {
       const relPath = vscode.workspace.asRelativePath(file);
       r.filesFound.set(relPath, true);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -95,7 +95,7 @@ export function deactivate(): void {
 // ─── Command Handlers ───
 
 async function collectData() {
-  const logEntries = scanCopilotLogs();
+  const logEntries = await scanCopilotLogs();
   const settings = scanSettings();
   const workspace = await scanWorkspace();
   const extensions = scanExtensions();

--- a/src/test/scanner.test.ts
+++ b/src/test/scanner.test.ts
@@ -1,5 +1,8 @@
-import { detectHintsInText, analyzeLogs } from '../core/scanner/logs';
+import { detectHintsInText, analyzeLogs, readLogFiles, MAX_LOG_BYTES, MAX_ENTRIES, LOG_MTIME_CUTOFF_MS } from '../core/scanner/logs';
 import type { LogEntry } from '../core/scanner/logs';
+import * as fsp from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
 
 describe('Scanner - Logs', () => {
   describe('detectHintsInText', () => {
@@ -90,5 +93,72 @@ describe('Scanner - analyzeLogs (debug log format)', () => {
     const summary = analyzeLogs(entries);
     expect(summary.hasVSCodeLogs).toBe(true);
     expect(summary.llmRequests).toBe(0);
+  });
+});
+
+describe('Scanner - readLogFiles bounds', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'ce-scan-'));
+  });
+
+  afterEach(async () => {
+    await fsp.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  test('skips files older than the mtime cutoff', async () => {
+    const oldFile = path.join(tmpDir, 'copilot-old.log');
+    const freshFile = path.join(tmpDir, 'copilot-fresh.log');
+    await fsp.writeFile(oldFile, JSON.stringify({ message: 'old' }) + '\n');
+    await fsp.writeFile(freshFile, JSON.stringify({ message: 'fresh' }) + '\n');
+
+    const ancient = (Date.now() - LOG_MTIME_CUTOFF_MS - 60_000) / 1000;
+    await fsp.utimes(oldFile, ancient, ancient);
+
+    const entries: LogEntry[] = [];
+    await readLogFiles(tmpDir, entries);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].message).toBe('fresh');
+  });
+
+  test('tail-reads files larger than MAX_LOG_BYTES and discards partial first line', async () => {
+    const big = path.join(tmpDir, 'copilot-big.log');
+    // Build a file that exceeds the cap. First half is junk we expect to be dropped.
+    const filler = 'x'.repeat(MAX_LOG_BYTES);
+    const tailLines = ['', JSON.stringify({ message: 'tail-line-1' }), JSON.stringify({ message: 'tail-line-2' })].join('\n');
+    await fsp.writeFile(big, filler + '\n' + tailLines);
+
+    const entries: LogEntry[] = [];
+    await readLogFiles(tmpDir, entries);
+    const messages = entries.map(e => e.message);
+    expect(messages).toEqual(expect.arrayContaining(['tail-line-1', 'tail-line-2']));
+    // The filler line should NOT be present as a single huge entry.
+    expect(messages.some(m => m.length >= MAX_LOG_BYTES)).toBe(false);
+  });
+
+  test('respects MAX_ENTRIES cap and signals stop', async () => {
+    // Write more than MAX_ENTRIES lines into a single file
+    const file = path.join(tmpDir, 'copilot-flood.log');
+    const lines: string[] = [];
+    const overflow = MAX_ENTRIES + 50;
+    for (let i = 0; i < overflow; i++) {
+      lines.push(JSON.stringify({ message: `m${i}` }));
+    }
+    await fsp.writeFile(file, lines.join('\n'));
+
+    const entries: LogEntry[] = [];
+    const stopped = await readLogFiles(tmpDir, entries);
+    expect(stopped).toBe(true);
+    expect(entries.length).toBe(MAX_ENTRIES);
+  });
+
+  test('ignores non-copilot files', async () => {
+    await fsp.writeFile(path.join(tmpDir, 'random.log'), JSON.stringify({ message: 'nope' }));
+    await fsp.writeFile(path.join(tmpDir, 'copilot-yes.log'), JSON.stringify({ message: 'yes' }));
+    const entries: LogEntry[] = [];
+    await readLogFiles(tmpDir, entries);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].message).toBe('yes');
   });
 });

--- a/src/test/scanner.test.ts
+++ b/src/test/scanner.test.ts
@@ -1,4 +1,4 @@
-import { detectHintsInText, analyzeLogs, readLogFiles, MAX_LOG_BYTES, MAX_ENTRIES, LOG_MTIME_CUTOFF_MS } from '../core/scanner/logs';
+import { detectHintsInText, analyzeLogs, readLogFiles, getWorkspaceStorageDebugLogPaths, MAX_LOG_BYTES, MAX_ENTRIES, LOG_MTIME_CUTOFF_MS, MAX_WORKSPACE_STORAGE_DIRS } from '../core/scanner/logs';
 import type { LogEntry } from '../core/scanner/logs';
 import * as fsp from 'fs/promises';
 import * as os from 'os';
@@ -98,14 +98,34 @@ describe('Scanner - analyzeLogs (debug log format)', () => {
 
 describe('Scanner - readLogFiles bounds', () => {
   let tmpDir: string;
+  let createdWorkspaceDirs: string[];
 
   beforeEach(async () => {
     tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'ce-scan-'));
+    createdWorkspaceDirs = [];
   });
 
   afterEach(async () => {
+    for (const workspaceDir of createdWorkspaceDirs) {
+      await fsp.rm(workspaceDir, { recursive: true, force: true });
+    }
     await fsp.rm(tmpDir, { recursive: true, force: true });
   });
+
+  function workspaceStorageBase(homeDir: string): string | undefined {
+    switch (process.platform) {
+      case 'win32': {
+        const appData = process.env['APPDATA'];
+        return appData ? path.join(appData, 'Code', 'User', 'workspaceStorage') : undefined;
+      }
+      case 'darwin':
+        return path.join(homeDir, 'Library', 'Application Support', 'Code', 'User', 'workspaceStorage');
+      case 'linux':
+        return path.join(homeDir, '.config', 'Code', 'User', 'workspaceStorage');
+      default:
+        return undefined;
+    }
+  }
 
   test('skips files older than the mtime cutoff', async () => {
     const oldFile = path.join(tmpDir, 'copilot-old.log');
@@ -160,5 +180,35 @@ describe('Scanner - readLogFiles bounds', () => {
     await readLogFiles(tmpDir, entries);
     expect(entries).toHaveLength(1);
     expect(entries[0].message).toBe('yes');
+  });
+
+  test('limits workspaceStorage debug-log scanning to the newest directories', async () => {
+    const storageBase = workspaceStorageBase(os.homedir());
+    if (!storageBase) {
+      return;
+    }
+
+    await fsp.mkdir(storageBase, { recursive: true });
+
+    const totalDirs = MAX_WORKSPACE_STORAGE_DIRS + 2;
+    const newestWorkspaceNames: string[] = [];
+    for (let i = 0; i < totalDirs; i++) {
+      const workspaceName = `ce-scan-ws-${process.pid}-${Date.now()}-${i}`;
+      const workspaceDir = path.join(storageBase, workspaceName);
+      const debugLogsDir = path.join(workspaceDir, 'GitHub.copilot-chat', 'debug-logs');
+      await fsp.mkdir(debugLogsDir, { recursive: true });
+      createdWorkspaceDirs.push(workspaceDir);
+      const mtime = new Date(Date.now() + i * 1_000);
+      await fsp.utimes(workspaceDir, mtime, mtime);
+      if (i >= totalDirs - MAX_WORKSPACE_STORAGE_DIRS) {
+        newestWorkspaceNames.unshift(workspaceName);
+      }
+    }
+
+    const paths = await getWorkspaceStorageDebugLogPaths();
+    const matchingPaths = paths.filter(p => createdWorkspaceDirs.some(dir => p.startsWith(dir)));
+
+    expect(matchingPaths).toHaveLength(MAX_WORKSPACE_STORAGE_DIRS);
+    expect(matchingPaths.map(p => path.basename(path.dirname(path.dirname(p))))).toEqual(newestWorkspaceNames);
   });
 });

--- a/src/test/scanner.test.ts
+++ b/src/test/scanner.test.ts
@@ -1,4 +1,4 @@
-import { detectHintsInText, analyzeLogs, readLogFiles, getWorkspaceStorageDebugLogPaths, MAX_LOG_BYTES, MAX_ENTRIES, LOG_MTIME_CUTOFF_MS, MAX_WORKSPACE_STORAGE_DIRS } from '../core/scanner/logs';
+import { detectHintsInText, analyzeLogs, readLogFiles, MAX_LOG_BYTES, MAX_ENTRIES, LOG_MTIME_CUTOFF_MS, MAX_WORKSPACE_STORAGE_DIRS } from '../core/scanner/logs';
 import type { LogEntry } from '../core/scanner/logs';
 import { randomUUID } from 'crypto';
 import * as fsp from 'fs/promises';
@@ -99,19 +99,33 @@ describe('Scanner - analyzeLogs (debug log format)', () => {
 
 describe('Scanner - readLogFiles bounds', () => {
   let tmpDir: string;
-  let createdWorkspaceDirs: string[];
+  let originalAppData: string | undefined;
 
   beforeEach(async () => {
     tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'ce-scan-'));
-    createdWorkspaceDirs = [];
+    originalAppData = process.env['APPDATA'];
   });
 
   afterEach(async () => {
-    for (const workspaceDir of createdWorkspaceDirs) {
-      await fsp.rm(workspaceDir, { recursive: true, force: true });
+    if (originalAppData === undefined) {
+      delete process.env['APPDATA'];
+    } else {
+      process.env['APPDATA'] = originalAppData;
     }
+    jest.resetModules();
+    jest.dontMock('os');
     await fsp.rm(tmpDir, { recursive: true, force: true });
   });
+
+  async function getWorkspaceStorageDebugLogPathsForHome(homeDir: string): Promise<string[]> {
+    jest.resetModules();
+    jest.doMock('os', () => ({
+      ...jest.requireActual('os'),
+      homedir: () => homeDir,
+    }));
+    const logs = await import('../core/scanner/logs');
+    return logs.getWorkspaceStorageDebugLogPaths();
+  }
 
   function workspaceStorageBase(homeDir: string): string | undefined {
     switch (process.platform) {
@@ -143,7 +157,7 @@ describe('Scanner - readLogFiles bounds', () => {
     expect(entries[0].message).toBe('fresh');
   });
 
-  test('tail-reads files larger than MAX_LOG_BYTES and discards partial first line', async () => {
+  test('tail-reads files larger than MAX_LOG_BYTES and discards a partial first line', async () => {
     const big = path.join(tmpDir, 'copilot-big.log');
     // Build a file that exceeds the cap. First half is junk we expect to be dropped.
     const filler = 'x'.repeat(MAX_LOG_BYTES);
@@ -184,7 +198,8 @@ describe('Scanner - readLogFiles bounds', () => {
   });
 
   test('limits workspaceStorage debug-log scanning to the newest directories', async () => {
-    const storageBase = workspaceStorageBase(os.homedir());
+    process.env['APPDATA'] = path.join(tmpDir, 'AppData', 'Roaming');
+    const storageBase = workspaceStorageBase(tmpDir);
     if (!storageBase) {
       return;
     }
@@ -199,7 +214,6 @@ describe('Scanner - readLogFiles bounds', () => {
       const workspaceDir = path.join(storageBase, workspaceName);
       const debugLogsDir = path.join(workspaceDir, 'GitHub.copilot-chat', 'debug-logs');
       await fsp.mkdir(debugLogsDir, { recursive: true });
-      createdWorkspaceDirs.push(workspaceDir);
       const mtime = new Date(Date.now() + i * 1_000);
       await fsp.utimes(workspaceDir, mtime, mtime);
       if (i >= totalDirs - MAX_WORKSPACE_STORAGE_DIRS) {
@@ -207,10 +221,9 @@ describe('Scanner - readLogFiles bounds', () => {
       }
     }
 
-    const paths = await getWorkspaceStorageDebugLogPaths();
-    const matchingPaths = paths.filter(p => createdWorkspaceDirs.some(dir => p.startsWith(dir)));
+    const paths = await getWorkspaceStorageDebugLogPathsForHome(tmpDir);
 
-    expect(matchingPaths).toHaveLength(MAX_WORKSPACE_STORAGE_DIRS);
-    expect(matchingPaths.map(p => path.basename(path.dirname(path.dirname(p))))).toEqual(newestWorkspaceNames);
+    expect(paths).toHaveLength(MAX_WORKSPACE_STORAGE_DIRS);
+    expect(paths.map(p => path.basename(path.dirname(path.dirname(p))))).toEqual(newestWorkspaceNames);
   });
 });

--- a/src/test/scanner.test.ts
+++ b/src/test/scanner.test.ts
@@ -1,5 +1,6 @@
 import { detectHintsInText, analyzeLogs, readLogFiles, getWorkspaceStorageDebugLogPaths, MAX_LOG_BYTES, MAX_ENTRIES, LOG_MTIME_CUTOFF_MS, MAX_WORKSPACE_STORAGE_DIRS } from '../core/scanner/logs';
 import type { LogEntry } from '../core/scanner/logs';
+import { randomUUID } from 'crypto';
 import * as fsp from 'fs/promises';
 import * as os from 'os';
 import * as path from 'path';
@@ -192,8 +193,9 @@ describe('Scanner - readLogFiles bounds', () => {
 
     const totalDirs = MAX_WORKSPACE_STORAGE_DIRS + 2;
     const newestWorkspaceNames: string[] = [];
+    const runId = randomUUID();
     for (let i = 0; i < totalDirs; i++) {
-      const workspaceName = `ce-scan-ws-${process.pid}-${Date.now()}-${i}`;
+      const workspaceName = `ce-scan-ws-${process.pid}-${runId}-${i}`;
       const workspaceDir = path.join(storageBase, workspaceName);
       const debugLogsDir = path.join(workspaceDir, 'GitHub.copilot-chat', 'debug-logs');
       await fsp.mkdir(debugLogsDir, { recursive: true });


### PR DESCRIPTION
## Perf 03 — Bound the log + workspace scanners

Activation no longer blocks on synchronous reads of tens of MB of historical Copilot logs.

### Changes

**`src/core/scanner/logs.ts`** — converted to fully async (`fs.promises`) and added bounds:
- **mtime cutoff** (`LOG_MTIME_CUTOFF_MS = 7 days`) — skip stale log files
- **per-file size cap** (`MAX_LOG_BYTES = 2 MB`) — for larger files, open + read the tail window and drop the (likely partial) first line
- **total entries cap** (`MAX_ENTRIES = 50,000`) — short-circuits the directory walk once hit
- **per-workspaceStorage cap** (`MAX_WORKSPACE_STORAGE_DIRS = 10`) — only the most-recently-modified workspace folders are scanned

**`src/core/scanner/workspace.ts`** — replaced the sequential `findFiles` loop with `Promise.all` over all detect-hint patterns.

**`src/extension.ts`** — `collectData()` now `await`s `scanCopilotLogs()`.

**`src/test/scanner.test.ts`** — new `readLogFiles bounds` suite covering all four guards using `fs.mkdtemp` fixtures.

### Validation
- `npm run lint` ✅
- `npm test` ✅ (403 tests pass)
- `npm run compile` ✅